### PR TITLE
add passthrough for logging arguments.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "sat-utils"
-version = "1.7.2"
+version = "1.7.3"
 authors = [
     { name="Ryan Semmler", email="rsemmle@ncsu.edu" },
     { name="Shawn Taylor", email="staylor8@ncsu.edu" },

--- a/sat/logs.py
+++ b/sat/logs.py
@@ -28,17 +28,17 @@ class SATLogger:
                 handler.setFormatter(self.formatter)
             self.logger.addHandler(handler)
 
-    def debug(self, msg: str) -> None:
-        self.logger.debug(msg)
+    def debug(self, msg: str, *args, **kwargs) -> None:
+        self.logger.debug(msg, *args, **kwargs)
 
-    def info(self, msg: str) -> None:
-        self.logger.info(msg)
+    def info(self, msg: str, *args, **kwargs) -> None:
+        self.logger.info(msg, *args, **kwargs)
 
-    def warning(self, msg: str) -> None:
-        self.logger.warning(msg)
+    def warning(self, msg: str, *args, **kwargs) -> None:
+        self.logger.warning(msg, *args, **kwargs)
 
-    def error(self, msg: str) -> None:
-        self.logger.error(msg)
+    def error(self, msg: str, *args, **kwargs) -> None:
+        self.logger.error(msg, *args, **kwargs)
 
-    def critical(self, msg: str) -> None:
-        self.logger.critical(msg)
+    def critical(self, msg: str, *args, **kwargs) -> None:
+        self.logger.critical(msg, args, kwargs)


### PR DESCRIPTION
allows us to pass in extra logging arguments

Just adds `args` and `kwargs` passthrough to all of the logger call wrapper methods on the `SATLogger` logging wrapper