### PR TITLE
Team 159 add custom formatter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "sat-utils"
-version = "1.7.3"
+version = "1.7.4"
 authors = [
     { name="Ryan Semmler", email="rsemmle@ncsu.edu" },
     { name="Shawn Taylor", email="staylor8@ncsu.edu" },

--- a/sat/logs.py
+++ b/sat/logs.py
@@ -44,6 +44,37 @@ class SATLogger:
         self.logger.critical(msg, args, kwargs)
 
 
+class DjangoSATLogger:
+    """
+    Just a wrapper class around the default logger
+
+    This exists just to keep the client side implementation of logging similar between the
+    django/celery applications and the other python services in our stack.
+
+    The default SATLogger implementation doesn't play nicely with UWSGI/Django/Celery altogether;
+    Django manages logging configuration through it's built in settings module.
+    The desired extra-argument formatter should be passed to
+    """
+
+    def __init__(self, name: str = __name__, level: int = logging.INFO) -> None:
+        self.logger = logging.getLogger(name)
+
+    def debug(self, msg: str, *args, **kwargs) -> None:
+        self.logger.debug(msg, *args, **kwargs)
+
+    def info(self, msg: str, *args, **kwargs) -> None:
+        self.logger.info(msg, *args, **kwargs)
+
+    def warning(self, msg: str, *args, **kwargs) -> None:
+        self.logger.warning(msg, *args, **kwargs)
+
+    def error(self, msg: str, *args, **kwargs) -> None:
+        self.logger.error(msg, *args, **kwargs)
+
+    def critical(self, msg: str, *args, **kwargs) -> None:
+        self.logger.critical(msg, args, kwargs)
+
+
 class ExtraTextFormatter(logging.Formatter):
     """
     Modifies the log format used based on the presence of extra variables in the log message

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,6 +1,9 @@
 import logging
 import os
+from io import StringIO
 from unittest import mock
+
+from sat.logs import ExtraTextFormatter
 
 TMP_FILE = "/tmp/test.log"
 
@@ -38,3 +41,36 @@ def test_add_handlers(caplog):
     logger.info("Test message")
     assert "Test message" in caplog.text
     assert os.path.exists(TMP_FILE)
+
+
+def test_extra_formatter():
+    test_stream = StringIO()
+    handler = logging.StreamHandler(test_stream)
+    formatter = ExtraTextFormatter()
+    handler.setFormatter(formatter)
+    logger = logging.getLogger(__name__)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.info("test", extra={"cid": "test"})
+    test_stream.seek(0)
+    log_line = test_stream.read()
+    assert "cid=test" in log_line
+
+
+def test_all_args_extra_formatter():
+    test_stream = StringIO()
+    handler = logging.StreamHandler(test_stream)
+    formatter = ExtraTextFormatter()
+    handler.setFormatter(formatter)
+    logger = logging.getLogger(__name__)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.info(
+        "test",
+        extra={"cid": "test", "first_name": "test-first-name", "last_name": "test-last-name"},
+    )
+    test_stream.seek(0)
+    log_line = test_stream.read()
+    assert "cid=test" in log_line
+    assert "first_name=test-first-name" in log_line
+    assert "last_name=test-last-name" in log_line

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -43,6 +43,15 @@ def test_add_handlers(caplog):
     assert os.path.exists(TMP_FILE)
 
 
+def test_django_logger(caplog):
+    from sat.logs import DjangoSATLogger
+
+    logger = DjangoSATLogger()
+    logger.logger.setLevel(logging.INFO)
+    logger.info("Test info")
+    assert "Test info" in caplog.text
+
+
 def test_extra_formatter():
     test_stream = StringIO()
     handler = logging.StreamHandler(test_stream)


### PR DESCRIPTION
Adds a custom log formatter class which handles optional extra arguments for the logging output

Adds a DjangoSATLogger class to be used with `sat-automations`/`django-automations`
 - The default way to doing things in SATLogger doesn't play nice with Django/Celery/UWSGI, instead of adding handlers in the init we should use the django logging settings to do that.
 - This class allows us to still initialize the logger in sat-automations the same way we've been doing it with SATLogger
 