### PR TITLE
Add back log level

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "sat-utils"
-version = "1.7.4"
+version = "1.7.5"
 authors = [
     { name="Ryan Semmler", email="rsemmle@ncsu.edu" },
     { name="Shawn Taylor", email="staylor8@ncsu.edu" },

--- a/sat/logs.py
+++ b/sat/logs.py
@@ -93,7 +93,7 @@ class ExtraTextFormatter(logging.Formatter):
     """
 
     def format(self, record):
-        log_format = "%(asctime)s %(name)s %(message)s "
+        log_format = "%(asctime)s %(levelname)s %(name)s %(message)s "
 
         # Convert attribute style extra args on the log record into optional values in a dictionary
         existing_extra_args = dict()


### PR DESCRIPTION
## Changes

Return loglevel to our python log format

This shouldn't have been removed in the first place

bumped the library version