### PR TITLE
Add python loglevel back to our shared logger's formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
     hooks:
       - id: bandit
         args: ["-c", "bandit.yml"]
+        additional_dependencies: ["pbr"]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: "v0.0.261"
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "sat-utils"
-version = "1.7.4"
+version = "1.7.5"
 authors = [
     { name="Ryan Semmler", email="rsemmle@ncsu.edu" },
     { name="Shawn Taylor", email="staylor8@ncsu.edu" },

--- a/sat/logs.py
+++ b/sat/logs.py
@@ -93,7 +93,7 @@ class ExtraTextFormatter(logging.Formatter):
     """
 
     def format(self, record):
-        log_format = "%(asctime)s %(name)s %(message)s "
+        log_format = "%(asctime)s %(levelname)s %(name)s %(message)s "
 
         # Convert attribute style extra args on the log record into optional values in a dictionary
         existing_extra_args = dict()


### PR DESCRIPTION
Adds loglevel back to the text formatter. Shouldn't have removed the loglevel in the first place.

Also includes an additional requirement to allow git pre-commits to work again correctly